### PR TITLE
feat(git): update from Angular 1x to Angular 2x convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ module.exports = {
 				'test',
 				'build',
 				'ci',
-				'chore'
+				'chore',
+				'revert'
 			]
 		]
 	},

--- a/index.js
+++ b/index.js
@@ -47,14 +47,16 @@ module.exports = {
 		'type-enum': [2,
 			'always',
 			[
-				'chore',
-				'docs',
 				'feat',
 				'fix',
-				'perf',
-				'refactor',
+				'docs',
 				'style',
-				'test'
+				'refactor',
+				'perf',
+				'test',
+				'build',
+				'ci',
+				'chore'
 			]
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-lint-config-angular",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Shareable conventional-changelog-lint config enforcing the angular commit convention",
   "main": "index.js",
   "scripts": {
@@ -32,15 +32,15 @@
   },
   "homepage": "https://github.com/marionebl/conventional-changelog-lint-config-angular#readme",
   "devDependencies": {
-    "commitizen": "2.5.0",
-    "conventional-changelog-cli": "1.1.1",
-    "conventional-changelog-lint": "0.3.0",
-    "conventional-recommended-bump": "0.1.1",
-    "cz-conventional-changelog": "1.1.5",
-    "eslint": "2.2.0",
-    "eslint-config-xo": "0.11.0",
-    "husky": "0.11.1",
-    "jsonlint-cli": "0.2.7"
+    "commitizen": "2.8.6",
+    "conventional-changelog-cli": "1.2.0",
+    "conventional-changelog-lint": "1.0.1",
+    "conventional-recommended-bump": "0.3.0",
+    "cz-conventional-changelog": "1.2.0",
+    "eslint": "3.9.1",
+    "eslint-config-xo": "0.17.0",
+    "husky": "0.11.9",
+    "jsonlint-cli": "1.0.1"
   },
   "peerDependencies": {
     "conventional-changelog-lint": ">=0.3.0"

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,8 @@ The following rules are considered problems for `conventional-changelog-lint-con
 		'test',
 		'build',
 		'ci',
-		'chore'
+		'chore',
+		'revert'
 	]
   ```
 

--- a/readme.md
+++ b/readme.md
@@ -30,16 +30,18 @@ The following rules are considered problems for `conventional-changelog-lint-con
 * **rule**: `always`
 * **value**
   ```js
-    [
-      'feat',
-      'fix',
-      'docs',
-      'style',
-      'refactor',
-      'test',
-      'chore',
-      'revert'
-    ]
+	[
+		'feat',
+		'fix',
+		'docs',
+		'style',
+		'refactor',
+		'perf',
+		'test',
+		'build',
+		'ci',
+		'chore'
+	]
   ```
 
 #### type-case


### PR DESCRIPTION
### Update Information:

Update commit convention from [Angular 1x](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#type) to [Angular 2x](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type).

- add: build, ci
- remove: revert

i also integrated this in [conventional-changelog-angular-emoji](https://github.com/ellerbrock/conventional-changelog-angular-emoji).

![](http://i.giphy.com/rn5Qb21qX0fxm.gif)